### PR TITLE
Experiment Succeed - Needed the full kernel suffix

### DIFF
--- a/.github/workflows/buildPackages.yml
+++ b/.github/workflows/buildPackages.yml
@@ -1,6 +1,7 @@
 name: Build XDNA Driver and XRT Packages
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - actions

--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2022-2023, Advanced Micro Devices, Inc. All rights reserved.
 
 # Use headers from Ubuntu 24.04 HWE kit kernel install
-set(KERNEL_VER KERNEL_VER=6.11.0)
+set(KERNEL_VER KERNEL_VER=6.11.0-19-generic)
 
 set(XDNA_DRV amdxdna)
 


### PR DESCRIPTION
Turns out that when you build the kernel from scratch, you don't get a long suffix created. If you put in the full name, this looks like the action succeeds. 